### PR TITLE
一日の献立詳細画面の作成

### DIFF
--- a/features/calendar/components/Day/DayCell.tsx
+++ b/features/calendar/components/Day/DayCell.tsx
@@ -5,12 +5,14 @@ import { Menu } from "../../types";
 type Props = {
   day: Date;
   menuList: Menu[];
+  onClick?: () => void;
 };
 
-export const DayCell = ({ day, menuList }: Props) => {
+export const DayCell = ({ day, menuList, onClick }: Props) => {
   return (
     <div className="flex flex-col items-center space-y-1">
       <button
+        onClick={onClick}
         className={`w-8 h-8 rounded-full flex items-center justify-center ${
           isToday(day) ? "bg-blue-500 text-white" : "text-black"
         }`}

--- a/features/calendar/components/Day/modal.tsx
+++ b/features/calendar/components/Day/modal.tsx
@@ -1,0 +1,31 @@
+import { ReactNode } from "react";
+
+type Props = {
+    isOpen: boolean;
+    onClose: () => void;
+    children: ReactNode;
+};
+
+export const Modal = ({ isOpen, onClose, children }: Props) => {
+    if (!isOpen) return null;
+
+    return (
+    <div
+        className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-50"
+        onClick={onClose}
+    >
+        <div
+        className="bg-white p-6 rounded-md shadow-md w-11/12 max-w-md"
+        onClick={(e) => e.stopPropagation()}
+        >
+        <button
+            onClick={onClose}
+            className="absolute top-2 right-2 text-gray-500 hover:text-black"
+        >
+            ✕
+        </button>
+        {children}
+        </div>
+    </div>
+    );
+};

--- a/features/calendar/components/Month/MonthView.tsx
+++ b/features/calendar/components/Month/MonthView.tsx
@@ -6,10 +6,11 @@ import { Menu } from "../../types";
 type Props = {
   currentMonth: Date;
   menuList: Menu[];
+  onSelectDate: (date: Date) => void;
   // mstTimeZone: { id: number, displayName: string }[];
 };
 
-export const MonthView = ({ currentMonth, menuList }: Props) => {
+export const MonthView = ({ currentMonth, menuList, onSelectDate }: Props) => {
   const days = eachDayOfInterval({
     start: startOfMonth(currentMonth),
     end: endOfMonth(currentMonth),
@@ -35,6 +36,7 @@ export const MonthView = ({ currentMonth, menuList }: Props) => {
               key={day.toDateString()}
               day={day}
               menuList={dayMenus}
+              onClick={() => onSelectDate(day)}
             />
           );
         })}

--- a/features/calendar/types/index.ts
+++ b/features/calendar/types/index.ts
@@ -3,7 +3,8 @@ export type Menu = {
   id: number;
   name: string;
   date: string;
-  timeZone: {
+    timeZone: {
+    id: number;
     displayName: string;
   };
   menuDishes: any[];

--- a/lib/func/menu.ts
+++ b/lib/func/menu.ts
@@ -74,48 +74,30 @@ export async function getMenuByDateForWeek(userId: number, date: Date) {
     });
 }
 
-export async function getMenuByDateForMonth(userId: number, date: Date) {
-    return await prisma.menu.findMany({
+export async function getMenuByDateForMonth(userId: number, date: Date) { 
+  return await prisma.menu.findMany({
     where: {
-        userId,
-        date: {
+      userId,
+      date: {
         gte: startOfMonth(date),
         lte: endOfMonth(date),
-        },
+      },
     },
     orderBy: {
-        timeZoneId: "asc",
+      timeZoneId: "asc",
     },
-    select: {
-        id: true,
-        name: true,
-        date: true,
-        timeZone: {
-        select: {
-            displayName: true,
-        },
-        },
-        menuDishes: {
-        select: {
-            id: true,
-            amount: true,
-            dish: {
-            select: {
-                name: true,
-                dishStatus: {
-                select: {
-                    displayName: true,
-                },
-                },
+    include: {
+      timeZone: true,
+      menuDishes: {
+        include: {
+          dish: {
+            include: {
+              dishStatus: true,
             },
-            },
-            quantity: {
-            select: {
-                displayName: true,
-            },
-            },
+          },
+          quantity: true,
         },
-        },
+      },
     },
-    });
+  });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "cors": "^2.8.5",
         "date-fns": "^4.1.0",
         "express": "^5.1.0",
+        "framer-motion": "^12.23.1",
         "lucide-react": "^0.525.0",
         "next": "15.3.5",
         "react": "^19.0.0",
@@ -1675,6 +1676,33 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.23.1",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.1.tgz",
+      "integrity": "sha512-7P1t2DnKEUXvPxVZJu9Hd4gfdoUF6z9U3w3/MUXCVFNHiFV+iSoboqeK4/ZCCpa49/ZiVEWfaaYCPscqPPsOVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.23.1",
+        "motion-utils": "^12.23.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fresh": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
@@ -2202,6 +2230,21 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.23.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.1.tgz",
+      "integrity": "sha512-kcMDS8yhUZgO7iu3FB0UYZpHUymZlj4aoEqH0Vf0k3JtZA0xfYIrmbDlKn6X7+INXV3hDAIBUf4aT5jEUHvvWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.23.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.23.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.1.tgz",
+      "integrity": "sha512-coqLmHUTBA1KyBNEO64sTCWlduDV5Q6Yv0szjxnHVzZmcFYpVowyP6S38iOUlhocannaCCHlZ06lyLWQe/jheQ==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "cors": "^2.8.5",
     "date-fns": "^4.1.0",
     "express": "^5.1.0",
+    "framer-motion": "^12.23.1",
     "lucide-react": "^0.525.0",
     "next": "15.3.5",
     "react": "^19.0.0",

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -5,16 +5,19 @@ import { addDays, addMonths, subDays, subMonths } from "date-fns";
 import { CalendarHeader } from "../../../features/calendar/components/Header/CalendarHeader";
 import { MonthView } from "../../../features/calendar/components/Month/MonthView";
 import { WeekView } from "../../../features/calendar/components/Week/WeekView";
+import { Modal } from "../../../features/calendar/components/Day/Modal";
 import { Menu, MstTimeZone } from "@prisma/client";
-
+import { isSameDay, format } from "date-fns";
 
 export default function CalendarPage() {
-  // const [mstTimeZone, setMstTimeZone] = useState<MstTimeZone[]>([]);
+  const [mstTimeZone, setMstTimeZone] = useState<MstTimeZone[]>([]);
   const [menuMonthList, setMenuMonth] = useState<Menu[]>([]);
   const [menuWeeklyList, setMenuWeekly] = useState<Menu[]>([]);
   const [viewMode, setViewMode] = useState<"month" | "week">("month");
   const [currentMonth, setCurrentMonth] = useState(new Date());
   const [currentWeekly, setCurrentWeekly] = useState(new Date());
+  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   // ページ読み込み時は現在の日付を取得してapiに渡す
   // 月切り替え時はその日時を取得してapiに渡す
@@ -44,15 +47,20 @@ export default function CalendarPage() {
     fetchMenu();
   }, [currentWeekly]);
 
+  const handleDateClick = (date: Date) => {
+    setSelectedDate(date);
+    setIsModalOpen(true);
+  };
+
   // タイムゾーンの取得
-  // useEffect(() => {
-  //   const fetchMstTimeZone = async () => {
-  //     const res = await fetch('/api/mstData/mstTimeZone');
-  //     const data = await res.json();
-  //     setMstTimeZone(data);
-  //   };
-  //   fetchMstTimeZone();
-  // }, []);
+  useEffect(() => {
+    const fetchMstTimeZone = async () => {
+      const res = await fetch('/api/mstData/mstTimeZone');
+      const data = await res.json();
+      setMstTimeZone(data);
+    };
+    fetchMstTimeZone();
+  }, []);
 
   const handleDelete = (day: string) => {
     console.log(`Delete ${day}`);
@@ -81,10 +89,37 @@ export default function CalendarPage() {
       />
 
       {viewMode === "month" ? (
-        <MonthView currentMonth={currentMonth} menuList={menuMonthList} />
+        <MonthView
+          currentMonth={currentMonth}
+          menuList={menuMonthList}
+          onSelectDate={handleDateClick}
+        />
       ) : (
         <WeekView currentWeek={currentWeekly} menuList={menuWeeklyList} onDelete={handleDelete} />
       )}
+      <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)}>
+        {selectedDate && (
+          <div>
+            <h2 className="text-lg font-bold mb-4 text-center">
+              {format(selectedDate, "yyyy/MM/dd")}
+            </h2>
+            <div className="space-y-2 text-sm">
+              {mstTimeZone.map((zone) => {
+                const meal = menuMonthList.find(
+                  (menu) =>
+                    isSameDay(new Date(menu.date), selectedDate) &&
+                    menu.timeZoneId === zone.id
+                );
+                return (
+                  <p key={zone.id}>
+                    {zone.displayName}: {meal ? meal.name : "register"}
+                  </p>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </Modal>
     </div>
   );
 }


### PR DESCRIPTION
月表示のカレンダーより、献立が設定されている日付をタップすると画像のような一日の献立詳細画面が表示される機能の作成
レイアウトについては調整中。

残タスク
・詳細画面から献立の追加、編集、削除が行えるようにする